### PR TITLE
Set Up Continuous Deployment Workflow with Updated SSH Key Configuration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description
+Added a route `GET /api/v1/books/{book_id}` to get a single book from the API.<br>
+The route will return a `404 ❌` if the book does not exist in the in-memory database.
+
+
+## Related Task
+[HNG12 Stage 2 Task](https://hng12.slack.com/archives/C088PK3KE2K/p1739195475622999)
+
+## How Has This Been Tested?
+- Ran `pytest` locally (and all passed)
+- Personally tested invalid endpoints with thunderclient (eg. `/books/78`) to confirm 404 response
+
+## Deployment
+- Configured Nginx as a reverse proxy for the FastAPI application
+
+## Final Notes
+- Added `hng12-devbotops` as a collaborator

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,12 +12,12 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Setting up SSH
-        uses: actions/ssh-agent@v0.5.3
+        uses: webfactory/ssh-agent@v0.5.3
         with: 
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       
       - name: Deploy the server
-        runs: |
+        run: |
           ssh -o StringHostKeyChecking=no ubuntu@20.115.88.88 << EOF
           cd ~/myproject/hng12-stage2-fastapi-with-pipeline
           git pull origin main

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,28 @@
+on:
+    push:
+        branches: [main]
+    
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v3
+            
+            - name: Set up SSH
+            - uses: webfactory/ssh-agent@v0.5.3
+              with: 
+                ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+            
+            - name: Deploy to Server
+              run: |
+                ssh -o StrictHostKeyChecking=no ubuntu@3.14.151.112 << 'EOF'
+                cd /var/www/myproject
+                git pull origin main
+                source vevn/bin/activate
+                pip install -r requirements.txt
+                sudo systemctl restart nginx
+                sudo systemctl restart fast_api_service
+                EOF

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,28 +1,29 @@
 on:
-    push:
-        branches: [main]
-    
+  push: 
+    branches: [main]
+
 
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
+  deploy:
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout Repository
-              uses: actions/checkout@v3
-            
-            - name: Set up SSH
-            - uses: webfactory/ssh-agent@v0.5.3
-              with: 
-                ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-            
-            - name: Deploy to Server
-              run: |
-                ssh -o StrictHostKeyChecking=no ubuntu@3.14.151.112 << 'EOF'
-                cd /var/www/myproject
-                git pull origin main
-                source vevn/bin/activate
-                pip install -r requirements.txt
-                sudo systemctl restart nginx
-                sudo systemctl restart fast_api_service
-                EOF
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      
+      - name: Setting up SSH
+        uses: actions/ssh-agent@v0.5.3
+        with: 
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      
+      - name: Deploy the server
+        runs: |
+          ssh -o StringHostKeyChecking=no ubuntu@20.115.88.88 << EOF
+          cd ~/myproject/hng12-stage2-fastapi-with-pipeline
+          git pull origin main
+          source venv/bin/activate
+          pip install -r requirements.txt
+          sudo systemctl restart nginx
+          sudo systemctl restart fast_api_service
+          EOF
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI test file  
+
+on:
+    pull_request:
+        branches: [main]
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v3
+            
+            - name: Setup Python Environment
+              uses: actions/setup-python@v4
+              with: 
+                python-version: '3.12'
+            
+
+            - name: Installing Dependencies
+              run: |
+                python -m pip install --upgrade pip
+                pip install -r requirements.txt
+
+            - name: Run Tests
+              run: pytest --maxfail=1

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install -r requirements.txt
 ```
 
 ## Running the Application
-
+  
 1. Start the server:
 
 ```bash

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -68,6 +68,6 @@ async def get_book(book_id: int) -> Book:
     book = db.get_book(book_id)
 
     if not book:
-        return JSONResponse(status_code=400, content={"detail": "Book not found"})
+        return JSONResponse(status_code=404, content={"detail": "Book not found"})
 
     return JSONResponse(status_code=status.HTTP_200_OK, content=book.model_dump())

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -60,3 +60,14 @@ async def update_book(book_id: int, book: Book) -> Book:
 async def delete_book(book_id: int) -> None:
     db.delete_book(book_id)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
+
+
+# Implementing the missing endpoint here
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int) -> Book:
+    book = db.get_book(book_id)
+
+    if not book:
+        return JSONResponse(status_code=400, content={"detail": "Book not found"})
+
+    return JSONResponse(status_code=status.HTTP_200_OK, content=book.model_dump())


### PR DESCRIPTION
## Description
Added a route `GET /api/v1/books/{book_id}` to get a single book from the API.<br>
The route will return a `404 ❌` if the book does not exist in the in-memory database.


## Related Task
[HNG12 Stage 2 Task](https://hng12.slack.com/archives/C088PK3KE2K/p1739195475622999)

## How Has This Been Tested?
- Ran `pytest` locally (and all passed)
- Personally tested invalid endpoints with thunderclient (eg. `/books/78`) to confirm 404 response

## Deployment
- Configured Nginx as a reverse proxy for the FastAPI application

## Final Notes
- Added `hng12-devbotops` as a collaborator
