### PR TITLE
Chore: Fixed error in cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
       
       - name: Deploy the server
         run: |
-          ssh -o StringHostKeyChecking=no ubuntu@20.115.88.88 << EOF
+          ssh -o StrictHostKeyChecking=no ubuntu@20.115.88.88 << EOF
           cd ~/myproject/hng12-stage2-fastapi-with-pipeline
           git pull origin main
           source venv/bin/activate


### PR DESCRIPTION
## Description
Added a route `GET /api/v1/books/{book_id}` to get a single book from the API.<br>
The route will return a `404 ❌` if the book does not exist in the in-memory database.


## Related Task
[HNG12 Stage 2 Task](https://hng12.slack.com/archives/C088PK3KE2K/p1739195475622999)

## How Has This Been Tested?
- Ran `pytest` locally (and all passed)
- Personally tested invalid endpoints with thunderclient (eg. `/books/78`) to confirm 404 response

## Deployment
- Configured Nginx as a reverse proxy for the FastAPI application

## Final Notes
- Added `hng12-devbotops` as a collaborator
