### PR TITLE
Chore: Modified the cd workflow so that the ssh-agent is configured a…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           ssh -o StrictHostKeyChecking=no ubuntu@20.115.88.88 << EOF
           cd ~/myproject/hng12-stage2-fastapi-with-pipeline
+          eval "$(ssh-agent -s)"
+          ssh-add /home/ubuntu/.ssh/github_ssh
           git pull origin main
           source venv/bin/activate
           pip install -r requirements.txt


### PR DESCRIPTION
## Description
### Issue
The codebase on the server was never updated with `git pull origin main` because the ssh-agent was no longer active
### Solution
Added to 2 lines to initialize the ssh-agent process and add the `github_ssh` to the ssh-agent
