### PR TITLE
Bug Fix: Fixed '~/.ssh cannot be found' error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,7 @@ jobs:
 
       - name: Create Server SSH key
         run: |
+          mkdir -p ~/.ssh
           echo "${{secrets.SSH_PRIVATE_KEY}}" > ~/.ssh/server_ssh
           chmod 600 ~/.ssh/server_key
       


### PR DESCRIPTION
## Description
Continuous deployment always reported that it could not find the directory '~/.ssh', so now the workflow creates one if it does not exist